### PR TITLE
Issue #488: Append footer to all mails generated by vufind

### DIFF
--- a/module/ixTheo/config/module.config.php
+++ b/module/ixTheo/config/module.config.php
@@ -40,6 +40,11 @@ $config = array(
             'pdasubscriptions' => 'VuFind\Controller\Plugin\PDASubscriptions',
         ]
     ],
+    'service_manager' => [
+        'factories' => [
+            'VuFind\Mailer' => 'ixTheo\Mailer\Factory',
+        ],
+    ],
 );
 
 $recordRoutes = array();

--- a/module/ixTheo/src/ixTheo/Mailer/Factory.php
+++ b/module/ixTheo/src/ixTheo/Mailer/Factory.php
@@ -1,0 +1,23 @@
+<?php
+namespace ixTheo\Mailer;
+
+use VuFind\Mailer;
+
+class Factory extends \VuFind\Mailer\Factory {
+    
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $sm Service manager
+     *
+     * @return mixed
+     */
+    public function createService(\Zend\ServiceManager\ServiceLocatorInterface $sm)
+    {
+        // Load configurations:
+        $config = $sm->get('VuFind\Config')->get('config');
+
+        // Create service:
+        return new IxTheoMailer($this->getTransport($config));
+    }
+}

--- a/module/ixTheo/src/ixTheo/Mailer/IxTheoMailer.php
+++ b/module/ixTheo/src/ixTheo/Mailer/IxTheoMailer.php
@@ -1,0 +1,38 @@
+<?php
+namespace ixTheo\Mailer;
+
+use VuFind\Mailer\Mailer;
+
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class IxTheoMailer extends \VuFind\Mailer\Mailer implements ServiceLocatorAwareInterface {
+    
+    use ServiceLocatorAwareTrait;
+    
+    /**
+     * Send an email message, append custom footer to body
+     *
+     * @param string|Address|AddressList $to      Recipient email address (or
+     * delimited list)
+     * @param string|Address             $from    Sender name and email address
+     * @param string                     $subject Subject line for message
+     * @param string                     $body    Message body
+     * @param string                     $cc      CC recipient (null for none)
+     *
+     * @throws MailException
+     * @return void
+     */
+    public function send($to, $from, $subject, $body, $cc = null)
+    {
+        $config = $this->getServiceLocator()->get('VuFind\Config')->get('config');
+        $email_enquiry = $config->Site->email_enquiry;
+        
+        if ($email_enquiry != null) {
+            $footer = 'If you have questions regarding this service please contact' . PHP_EOL . $email_enquiry;
+            $body .= PHP_EOL . '--' . PHP_EOL . $footer;
+        }
+        
+        parent::send($to, $from, $subject, $body, $cc);
+    }
+}

--- a/themes/ixTheoTheme/templates/static/de/Home.phtml
+++ b/themes/ixTheoTheme/templates/static/de/Home.phtml
@@ -178,7 +178,7 @@ $panelWidth = "col-md-6";
 
                         <h3>Alerting-Funktion</h3>
                         <p>Die Alerting Funktion unterrichtet Sie über neu erschienene Aufsätze aus Zeitschriften und neu
-                            erschienene Bände in Reihen und Fortsetzungen. Sie können frei entscheiden, in welchen Fällen
+                            erschienene Bände in Reihen. Sie können frei entscheiden, in welchen Fällen
                             Sie
                             eine Benachrichtigung wünschen.</p>
                         <p>Um eine Zeitschrift oder eine Reihe für das Alerting auszuwählen, müssen Sie die Gesamtaufnahme

--- a/themes/ixTheoTheme/templates/static/de/SubscriptionInfoText.phtml
+++ b/themes/ixTheoTheme/templates/static/de/SubscriptionInfoText.phtml
@@ -1,3 +1,3 @@
 <p>Die Alerting Funktion unterrichtet Sie über neu erschienene Aufsätze aus Zeitschriften und neu erschienene Bände in
-    Reihen und Fortsetzungen.</p>
+    Reihen.</p>
 <p>Um diesen Titel für den Neuerscheinungsdienst zu abonnieren, klicken Sie auf den Button "Abonnieren".</p>

--- a/themes/relBibTheme/templates/static/de/Home.phtml
+++ b/themes/relBibTheme/templates/static/de/Home.phtml
@@ -183,7 +183,7 @@ $panelWidth = "col-md-6";
 
                         <h3>Neuerscheinungen abonnieren (Alerting-Funktion)</h3>
                         <p>Mit dieser Funktion können Sie sich über neu erschienene Aufsätze aus Zeitschriften und neu erschienene Bände in Reihen 
-                           und Fortsetzungen benachrichtigen lassen. Sie entscheiden selbst, in welchen Fällen Sie eine Benachrichtigung wünschen.</p>
+                           benachrichtigen lassen. Sie entscheiden selbst, in welchen Fällen Sie eine Benachrichtigung wünschen.</p>
                         <p>Um eine Zeitschrift oder eine Reihe für das Alerting auszuwählen, müssen Sie die Gesamtaufnahme
                            der Zeitschrift oder Reihe subskribieren. Klicken Sie dazu auf das Symbol "Glocke", die Sie rechts
                            im entsprechenden Datensatz sehen. In Ihrem Konto können Sie die Subskriptionen verwalten.</p>


### PR DESCRIPTION
- ("If you have questions regarding this service please contact...")
- mail address for footer can be configured via "email_enquiry" setting in local_overrides\*_site.conf